### PR TITLE
docs+chore: atualiza README e SonarCloud projectKey para 2026.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,73 @@
-# 2024-2 MeasureSoftGram-Core
+# 2026.1 MeasureSoftGram-Core
 
-## Badges
-
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=bugs)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2023-1-MeasureSoftGram-Core&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2023-1-MeasureSoftGram-Core)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=bugs)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2026.1-MeasureSoftGram-Core&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=fga-eps-mds_2026.1-MeasureSoftGram-Core)
 
 ## What is it?
 
-The MeasureSoftGram-Core is a Software system for continuous quality of product observation and multidimensional use in continuous design engineering software and is where you have the innovative mathematical models for software analysis.
+The MeasureSoftGram-Core is a software system for continuous quality of product observation and multidimensional use in continuous design engineering software, and is where the innovative mathematical models for software analysis live.
 
 ## How to use MeasureSoftGram Core
--[How to use](https://fga-eps-mds.github.io/2021-2-MeasureSoftGram-Doc/docs/artifact/how_to_use)
+
+- [How to use](https://fga-eps-mds.github.io/2026.1-MeasureSoftGram-DOC/docs/artifact/how_to_use)
 
 ## How to run Core
 
-Made the container with :
-
-```
-docker-compose up
+```bash
+docker compose up
 ```
 
 ## How to run tests
 
-Install this dependencies
+Install dependencies:
 
-```
+```bash
 pip install -r requirements.txt
 ```
 
-We are using tox for the tests, so it is good to install the tox:
+We use `tox` for tests:
 
-```
+```bash
 pip install tox
+tox
 ```
 
-Then you can run the tests using
+To run a specific package or file:
 
-```
- tox 
-```
-
-if you want to especify the file use:
-```
- tox <PACKAGE OR FILE>
+```bash
+tox <PACKAGE OR FILE>
 ```
 
-If it does not work, you can try to run before: 
-```
+If it doesn't work, try first:
+
+```bash
 pip install pytest-mock
 ```
 
 ## Contribute
 
-Do you want to contribute with our project? Access our [contribution guide](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Core/blob/develop/CONTRIBUTING.md) where we explain how you do it. 
+Do you want to contribute with our project? Access our [contribution guide](./CONTRIBUTING.md) where we explain how you do it.
+
+## Code of Conduct
+
+We follow a [Code of Conduct](./CODE_OF_CONDUCT.md) — please read it before contributing.
 
 ## License
 
-AGPL-3.0 License
+[GNU AGPL-3.0 License](./LICENSE)
 
-### Documentation
+## Documentation
 
-The documentation of this project can be accessed at this website: [Documentation](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc).
+The documentation of this project can be accessed at: [Documentation](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-DOC).
 
 ## Another informations
 
@@ -77,8 +75,6 @@ Our services are available on [Docker Hub](https://hub.docker.com/):
 - [Core](https://hub.docker.com/r/measuresoftgram/core)
 - [Service](https://hub.docker.com/r/measuresoftgram/service)
 
-### Wiki
+## Wiki
 
-For more informations, you can see our wiki:
-- [Wiki](https://fga-eps-mds.github.io/2023-1-MeasureSoftGram-Doc/)
-
+For more information, see our [wiki](https://fga-eps-mds.github.io/2026.1-MeasureSoftGram-DOC/).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=fga-eps-mds_2024.1-MeasureSoftGram-Core
+sonar.projectKey=fga-eps-mds_2026.1-MeasureSoftGram-Core
 sonar.organization=fga-eps-mds-1
 
 sonar.python.version=3


### PR DESCRIPTION
## Descrição

Atualiza metadados do repo Core que ficaram do fork de semestres anteriores.

- **README**: header `2024-2` → `2026.1`, badges SonarCloud apontando para o projeto do semestre, links de Doc/Wiki/Contributing internos do repo, comandos atualizados pra `docker compose` v2.
- **sonar-project.properties**: `projectKey` `2024.1` → `2026.1`.

LICENSE (AGPL-3.0), CODE_OF_CONDUCT.md e CONTRIBUTING.md já estavam corretos no repo. A parte que faltava no Core para fechar as issues #218/#219 era apenas o ajuste de versão dos metadados.

## Issues cobertas

- #218 LICENSE: Adicionar a licença AGPL-3.0 aos repositórios (validação metadado)
- #219 Docs: Atualizar Code of Conduct e Contributing de todos os repositórios (links no README)

## Mudanças

| Arquivo | Status | Mudança |
|---|---|---|
| README.md | M | header, badges, links Doc/Wiki/Contributing/Conduct, docker compose v2 |
| sonar-project.properties | M | projectKey 2024.1 → 2026.1 |

## Como testar

1. Verificar que badges no README respondem após próximo build SonarCloud.
2. Conferir que `sonar.projectKey` casa com o projeto SonarCloud configurado para 2026.1.
