### PR TITLE
fix(constants): memory_utilization aponta memory_usage em vez de cpu_usage

### DIFF
--- a/src/resources/constants.py
+++ b/src/resources/constants.py
@@ -135,7 +135,7 @@ AVAILABLE_PRE_CONFIGS = {
             "name": "Memory Utilization",
             "subcharacteristics": ["resource_utilization"],
             "characteristics": ["performance_efficiency"],
-            "metrics": ["endpoint_calls", "cpu_usage"],
+            "metrics": ["endpoint_calls", "memory_usage"],
         },
     },
 }

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,0 +1,18 @@
+from resources.constants import AVAILABLE_PRE_CONFIGS
+
+
+def test_memory_utilization_uses_memory_usage_metric():
+    """Issue #13: memory_utilization listava cpu_usage por copy-paste de
+    cpu_utilization. A medida deve consumir memory_usage (métrica canônica
+    em supported_metrics.py), nunca cpu_usage."""
+    memory_utilization = AVAILABLE_PRE_CONFIGS["measures"]["memory_utilization"]
+    metrics = memory_utilization["metrics"]
+
+    assert "cpu_usage" not in metrics, (
+        "memory_utilization não pode listar cpu_usage como métrica "
+        "(copy-paste bug do cpu_utilization — issue #13)."
+    )
+    assert "memory_usage" in metrics, (
+        "memory_utilization deve listar memory_usage como métrica, "
+        "alinhado com supported_metrics.py."
+    )


### PR DESCRIPTION
## Descrição

`memory_utilization` em `src/resources/constants.py` listava `cpu_usage` como métrica em vez de `memory_usage` (nome canônico declarado em `src/staticfiles/supported_metrics.py`). Era um copy-paste de `cpu_utilization`.

[Issue #13](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Core/issues/13)

## Porque este Pull Request é necessário?

A medida `memory_utilization` ficava semanticamente quebrada: era calculada com a métrica de CPU em vez da métrica de memória. Qualquer release que dependesse dessa medida tinha resultado errado.

## Como foi corrigido

TDD estrito em 2 commits:
- **RED** (`201bdde`): teste novo `test_memory_utilization_uses_memory_usage_metric` que falha provando o bug.
- **GREEN** (`b7064e4`): troca `cpu_usage` por `memory_usage` em `constants.py` — fix mínimo, 1 linha.

## Critérios de aceitação

1. [x] Teste novo prova o bug (RED) e passa após o fix (GREEN).
2. [x] Suite de testes completa passa.
3. [x] Lint (`black --check`, `flake8`) limpo.
4. [x] Nenhum teste pré-existente quebrou.

Closes #13