### PR TITLE
fix(core): ci_feedback_time gain_interpretation = -1 (menor é melhor)

### DIFF
--- a/src/core/aggregated_normalized_measures.py
+++ b/src/core/aggregated_normalized_measures.py
@@ -345,7 +345,7 @@ def ci_feedback_time(
         x=ci_feedback_time_value,
         min_threshold=min_threshold,
         max_threshold=max_threshold,
-        gain_interpretation=1,
+        gain_interpretation=-1,
     )
 
     aggregated_and_normalized_measure = transformations.calculate_measure(

--- a/tests/unit/test_aggregated_normalized_measures.py
+++ b/tests/unit/test_aggregated_normalized_measures.py
@@ -1,5 +1,6 @@
 import pytest
 
+from core.aggregated_normalized_measures import ci_feedback_time
 from tests.utils.aggregated_normalized_measures_data import (
     INVALID_METRICS_TEST_DATA,
     INVALID_THRESHOLD_TEST_DATA,
@@ -59,3 +60,30 @@ def test_aggregated_normalized_measures_invalid_thresholds(
         aggregated_normalized_measure(**params)
 
     assert str(error.value) == error_msg
+
+
+def test_ci_feedback_time_fast_pipeline_yields_high_measure():
+    """
+    Regression test for issue #15.
+
+    Semantica: ci_feedback_time mede o tempo medio de feedback do CI;
+    menos tempo = melhor (mesma convencao de fast_test_builds, que usa
+    gain_interpretation=-1). Portanto um pipeline rapido (60s/build,
+    bem dentro do limite max_threshold=900) deve produzir uma medida
+    ALTA (proximo de 1.0), nao baixa.
+
+    Hoje (bug) o codigo usa gain_interpretation=+1, invertendo a
+    interpretacao e retornando ~0.066 para esse cenario. Esperamos
+    >= 0.5 (idealmente ~0.934).
+    """
+    data_frame = {
+        "total_builds": 10,
+        "sum_ci_feedback_times": 600,  # media de 60s/build (rapido)
+    }
+
+    result = ci_feedback_time(data_frame)
+
+    assert result >= 0.5, (
+        f"CI rapido (60s/build) deveria render medida alta, mas obteve {result}. "
+        "Provavel inversao de gain_interpretation em ci_feedback_time."
+    )

--- a/tests/utils/analysis_data.py
+++ b/tests/utils/analysis_data.py
@@ -274,7 +274,7 @@ CALCULATE_MEASURES_RESULT_DATA = {
         {"key": "passed_tests", "value": 1.0},
         {"key": "test_builds", "value": 0.9995933399758454},
         {"key": "test_coverage", "value": 0.23425},
-        {"key": "ci_feedback_time", "value": 0.0},
+        {"key": "ci_feedback_time", "value": 1.0},
         {"key": "non_complex_file_density", "value": 0.8603745807930887},
         {"key": "commented_file_density", "value": 0.0935},
         {"key": "duplication_absense", "value": 0.0},


### PR DESCRIPTION
## Descrição

`ci_feedback_time` (`src/core/aggregated_normalized_measures.py:348`) tinha `gain_interpretation=+1` (maior é melhor), invertendo a semântica. Tempo de feedback do CI: quanto menor, melhor. Correto: `-1`.

[Issue #15](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Core/issues/15)

## Porque este Pull Request é necessário?

Com a interpretação invertida, pipelines lentos eram premiados e pipelines rápidos puniam a nota — exatamente o oposto da intenção. Além disso, era o único outlier do módulo: `fast_test_builds` (linha 224) e `run_time_measure` (linha 414), as outras 2 medidas temporais, já usam `-1`.

## Como foi corrigido

TDD estrito em 2 commits:
- **RED** (`e36980e`): teste `test_ci_feedback_time_fast_pipeline_yields_high_measure` passa `total_builds=10`, `sum_ci_feedback_times=600` (60s/build, rápido) e assevera `result >= 0.5`. Hoje retorna `0.0656...` — falha.
- **GREEN** (`cad1980`): troca `+1` por `-1`. Atualiza fixture `tests/utils/analysis_data.py:277` (`0.0` → `1.0`) que encodava o output do bug.

## Critérios de aceitação

1. [x] Teste novo prova semântica invertida (RED) e passa após fix (GREEN).
2. [x] Fixture que encodava output bugado atualizada no commit GREEN.
3. [x] Suite completa passa (74 passed).
4. [x] Convenção consistente: todas as 3 medidas temporais do módulo agora têm `gain_interpretation=-1`.
5. [x] Lint limpo.

Closes #15