### PR TITLE
fix(util): calculate_cliff_delta itera release_2 no loop interno

### DIFF
--- a/src/util/run_time_data_operations.py
+++ b/src/util/run_time_data_operations.py
@@ -85,11 +85,12 @@ class RunTimeDataOperations:
     def calculate_cliff_delta(
         self, release_1_metrics: pd.DataFrame, release_2_metrics: pd.DataFrame
     ):
-        size = len(release_1_metrics)
+        size_1 = len(release_1_metrics)
+        size_2 = len(release_2_metrics)
         sum = 0
 
-        for index_base in range(len(release_1_metrics)):
-            for index_alvo in range(len(release_1_metrics)):
+        for index_base in range(size_1):
+            for index_alvo in range(size_2):
                 value = 0
 
                 if release_1_metrics[index_base] < release_2_metrics[index_alvo]:
@@ -100,4 +101,4 @@ class RunTimeDataOperations:
 
                 sum += value
 
-        return abs(sum / (size * size))
+        return abs(sum / (size_1 * size_2))

--- a/tests/unit/test_run_time_data_operations.py
+++ b/tests/unit/test_run_time_data_operations.py
@@ -1,0 +1,46 @@
+import pytest
+
+from util.run_time_data_operations import RunTimeDataOperations
+
+
+@pytest.fixture
+def run_time_ops():
+    return RunTimeDataOperations()
+
+
+# Regression for issue #12: o loop interno de calculate_cliff_delta
+# iterava sobre len(release_1_metrics) em vez de len(release_2_metrics),
+# comparando release_1 x (slice de release_2 com tamanho de release_1).
+# Quando |release_1| > |release_2| isso causa IndexError; quando
+# |release_1| < |release_2| valores de release_2 sao silenciosamente
+# descartados. Esses testes usam tamanhos distintos para expor o bug.
+
+
+def test_cliff_delta_total_positive_separation_asymmetric_lengths(run_time_ops):
+    # Todos elementos de release_1 sao maiores que todos de release_2.
+    # Cliff's delta correto = +1.0 (a funcao retorna abs(), entao 1.0).
+    release_1 = [10, 20, 30, 40, 50]
+    release_2 = [1, 2, 3]
+    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(1.0)
+
+
+def test_cliff_delta_total_negative_separation_asymmetric_lengths(run_time_ops):
+    # Todos elementos de release_1 sao menores que todos de release_2.
+    # Cliff's delta correto = -1.0; com abs() vira 1.0.
+    release_1 = [1, 2, 3]
+    release_2 = [10, 20, 30, 40, 50]
+    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(1.0)
+
+
+def test_cliff_delta_asymmetric_known_value(run_time_ops):
+    # release_1 = [1, 2, 3], release_2 = [2, 3, 4, 5].
+    # Pares (x in r1, y in r2), n1*n2 = 12.
+    # x>y: (3,2) -> 1 par.
+    # x<y: (1,2),(1,3),(1,4),(1,5),(2,3),(2,4),(2,5),(3,4),(3,5) -> 9 pares.
+    # x=y: (2,2),(3,3) -> 2 pares (contribuem 0).
+    # delta = (1 - 9) / 12 = -0.6666...; abs = 0.6666...
+    release_1 = [1, 2, 3]
+    release_2 = [2, 3, 4, 5]
+    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(
+        8 / 12
+    )

--- a/tests/unit/test_run_time_data_operations.py
+++ b/tests/unit/test_run_time_data_operations.py
@@ -21,7 +21,9 @@ def test_cliff_delta_total_positive_separation_asymmetric_lengths(run_time_ops):
     # Cliff's delta correto = +1.0 (a funcao retorna abs(), entao 1.0).
     release_1 = [10, 20, 30, 40, 50]
     release_2 = [1, 2, 3]
-    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(1.0)
+    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(
+        1.0
+    )
 
 
 def test_cliff_delta_total_negative_separation_asymmetric_lengths(run_time_ops):
@@ -29,7 +31,9 @@ def test_cliff_delta_total_negative_separation_asymmetric_lengths(run_time_ops):
     # Cliff's delta correto = -1.0; com abs() vira 1.0.
     release_1 = [1, 2, 3]
     release_2 = [10, 20, 30, 40, 50]
-    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(1.0)
+    assert run_time_ops.calculate_cliff_delta(release_1, release_2) == pytest.approx(
+        1.0
+    )
 
 
 def test_cliff_delta_asymmetric_known_value(run_time_ops):


### PR DESCRIPTION
## Descrição

`calculate_cliff_delta` em `src/util/run_time_data_operations.py:92` iterava sobre `release_1_metrics` no loop interno em vez de `release_2_metrics`. Denominador também estava errado (`size * size` em vez de `size_1 * size_2`). Resultado: Cliff's delta matematicamente incorreto.

[Issue #12](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Core/issues/12)

## Porque este Pull Request é necessário?

Cliff's delta clássico (Cliff, 1993):
```
delta = (#{(x,y) : x > y} - #{(x,y) : x < y}) / (n1 * n2)
```
onde `x ∈ release_1`, `y ∈ release_2`. Com o loop iterando `release_1` em vez de `release_2`:

- **`|r1| > |r2|`**: `IndexError` em produção (acessa índice inexistente em `r2`).
- **`|r1| < |r2|`**: elementos extras de `r2` silenciosamente descartados — effect size enviesado.
- **`|r1| == |r2|`**: coincidentemente correto.

## Bug latente — não explodia em produção

Único caller real (`src/core/aggregated_normalized_measures.py:406`, função `run_time_measure`) sempre passa séries de mesmo tamanho, caindo no caso (3). Por isso nenhum teste pré-existente capturava. Mas é bomba-relógio: qualquer caller futuro com tamanhos distintos quebra ou retorna lixo.

## Como foi corrigido

TDD estrito em 2 commits:
- **RED** (`fc8b099`): 3 testes em `tests/unit/test_run_time_data_operations.py` (arquivo novo) cobrindo separação total positiva, separação total negativa, e caso assimétrico com valor manual conhecido (`8/12 ≈ 0.6667`).
- **GREEN** (`005b461`): troca `release_1_metrics` por `release_2_metrics` no loop interno; corrige denominador pra `size_1 * size_2`.

## Smell adicional (não nesse PR)

A função retorna `abs(...)`, perdendo o sinal do Cliff's delta clássico. Pode ser intencional (consumidor só usa magnitude), mas vale revisar. Issue separada cabe.

## Critérios de aceitação

1. [x] Testes provam fórmula incorreta (RED) e correta (GREEN).
2. [x] 3 casos: separação total positiva (+1), negativa (+1 por causa do `abs`), assimétrico não-trivial.
3. [x] Suite completa passa (76 passed — 3 testes novos).
4. [x] Lint limpo.

Closes #12